### PR TITLE
fix: allow dollar-sign in arguments

### DIFF
--- a/esno.js
+++ b/esno.js
@@ -1,12 +1,9 @@
 #!/usr/bin/env node
 
-const { execSync } = require('child_process')
+const { spawnSync } = require('child_process')
 
 const register = require.resolve('esbuild-register')
 
-const argv = process.argv
-  .slice(2)
-  .map((i) => `"${i}"`)
-  .join(' ')
+const argv = process.argv.slice(2)
 
-execSync(`node -r ${register} ${argv}`, { stdio: 'inherit' })
+spawnSync('node', ['-r', register, ...argv], { stdio: 'inherit' })


### PR DESCRIPTION
Using esno with a dollar-sign in the arguments didn't work because each argv was wrapped with double quotes:

```
esno ./file.ts '$string'
```

or

```
esno ./file.ts \$string
```


Double quotes [allows the shell to interpret variables (dollar-sign-prefixed strings)](https://www.geeksforgeeks.org/difference-between-single-and-double-quotes-in-shell-script-and-linux/) and other syntax inside of it.

Single quotes would be a better escaping method, but I opted to pass the argvs literally as they're given so that there are no quote collision issues.