### PR TITLE
chore: add typescript as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "esno.js",
     "esmo.mjs"
   ],
+  "peerDependencies": {
+    "typescript": "^4.0"
+  },
   "devDependencies": {
     "fsxx": "^0.0.5",
     "typescript": "^4.5.4",


### PR DESCRIPTION
esbuild-node-loader requires typescript as peer dependency, so we propagate it
